### PR TITLE
Add compatibility to removed color space options in 2.81

### DIFF
--- a/blender/LilySurfaceScrapper/CyclesMaterialData.py
+++ b/blender/LilySurfaceScrapper/CyclesMaterialData.py
@@ -65,7 +65,10 @@ class CyclesMaterialData(MaterialData):
             texture_node = nodes.new(type="ShaderNodeTexImage")
             texture_node.image = getCyclesImage(img)
             texture_node.image.colorspace_settings.name = "sRGB" if map_name == "baseColor" else "Non-Color"
-            texture_node.color_space = "COLOR" if map_name == "baseColor" else "NONE"
+            try:
+                texture_node.color_space = "COLOR" if map_name == "baseColor" else "NONE"
+            except:
+                pass
             if map_name == "opacity":
                 transparence_node = nodes.new(type="ShaderNodeBsdfTransparent")
                 mix_node = nodes.new(type="ShaderNodeMixShader")

--- a/blender/LilySurfaceScrapper/CyclesMaterialData.py
+++ b/blender/LilySurfaceScrapper/CyclesMaterialData.py
@@ -65,10 +65,8 @@ class CyclesMaterialData(MaterialData):
             texture_node = nodes.new(type="ShaderNodeTexImage")
             texture_node.image = getCyclesImage(img)
             texture_node.image.colorspace_settings.name = "sRGB" if map_name == "baseColor" else "Non-Color"
-            try:
+            if hasattr(texture_node, "color_space"):
                 texture_node.color_space = "COLOR" if map_name == "baseColor" else "NONE"
-            except:
-                pass
             if map_name == "opacity":
                 transparence_node = nodes.new(type="ShaderNodeBsdfTransparent")
                 mix_node = nodes.new(type="ShaderNodeMixShader")

--- a/blender/LilySurfaceScrapper/CyclesWorldData.py
+++ b/blender/LilySurfaceScrapper/CyclesWorldData.py
@@ -52,7 +52,10 @@ class CyclesWorldData(WorldData):
             texture_node = nodes.new(type="ShaderNodeTexEnvironment")
             texture_node.image = getCyclesImage(img)
             texture_node.image.colorspace_settings.name = "sRGB"
-            texture_node.color_space = "COLOR"
+            try:
+                texture_node.color_space = "COLOR"
+            except:
+                pass
             links.new(texture_node.outputs[texture_color_output], background.inputs[background_color_input])
         
         autoAlignNodes(world_output)

--- a/blender/LilySurfaceScrapper/CyclesWorldData.py
+++ b/blender/LilySurfaceScrapper/CyclesWorldData.py
@@ -52,10 +52,8 @@ class CyclesWorldData(WorldData):
             texture_node = nodes.new(type="ShaderNodeTexEnvironment")
             texture_node.image = getCyclesImage(img)
             texture_node.image.colorspace_settings.name = "sRGB"
-            try:
+            if hasattr(texture_node, "color_space"):
                 texture_node.color_space = "COLOR"
-            except:
-                pass
             links.new(texture_node.outputs[texture_color_output], background.inputs[background_color_input])
         
         autoAlignNodes(world_output)


### PR DESCRIPTION
Super ugly solution, but it works.
See here https://github.com/eliemichel/LilySurfaceScrapper/issues/10
