### PR TITLE
Add support for more map types

### DIFF
--- a/blender/LilySurfaceScrapper/CyclesMaterialData.py
+++ b/blender/LilySurfaceScrapper/CyclesMaterialData.py
@@ -6,7 +6,6 @@
 
 import bpy
 from bpy_extras.node_shader_utils import PrincipledBSDFWrapper
-
 from .MaterialData import MaterialData
 from .cycles_utils import getCyclesImage, autoAlignNodes
 
@@ -14,15 +13,15 @@ class CyclesMaterialData(MaterialData):
     # Translate our internal map names into cycles principled inputs
     input_tr = {
         'baseColor': 'Base Color',
-        'normal': 'Normal',
         'roughness': 'Roughness',
         'metallic': 'Metallic',
         'specular': 'Specular',
         'opacity': 'Alpha',
         'emission': 'Emission',
-        'height': '<custom>',
-        'ambientOcclusion': '<custom>', # https://github.com/KhronosGroup/glTF-Blender-IO/issues/123
-        'glossiness': '<custom>',
+        'normal': '',
+        'height': '',
+        'ambientOcclusion': '', # https://github.com/KhronosGroup/glTF-Blender-IO/issues/123
+        'glossiness': '',
     }
 
     def loadImages(self):
@@ -40,59 +39,66 @@ class CyclesMaterialData(MaterialData):
         links = mat.node_tree.links
         principled_mat = PrincipledBSDFWrapper(mat, is_readonly=False)
         principled = principled_mat.node_principled_bsdf
-        back_principled = None
         mat_output = principled_mat.node_out
         principled_mat.roughness = 1.0
-        normal_node = None
-        displacement_node = None
+        front = {}
+        back = {}
 
+        # Create all of the texture nodes
         for map_name, img in self.maps.items():
             if img is None or map_name.split("_")[0] not in __class__.input_tr:
                 continue
-
-            current_principled = principled
-            if map_name.endswith("_back"):
-                if back_principled is None:
-                    # Create backface principled and connect it
-                    back_principled = nodes.new(type="ShaderNodeBsdfPrincipled")
-                    geometry_node = nodes.new(type="ShaderNodeNewGeometry")
-                    mix_node = nodes.new(type="ShaderNodeMixShader")
-                    back_principled.inputs["Roughness"].default_value = 1.0
-                    links.new(geometry_node.outputs["Backfacing"], mix_node.inputs[0])
-                    links.new(principled.outputs[0], mix_node.inputs[1])
-                    links.new(back_principled.outputs[0], mix_node.inputs[2])
-                    links.new(mix_node.outputs[0], mat_output.inputs[0])
-                current_principled = back_principled
-                map_name = map_name[:-5]  # remove "_back"
-                
+            
             texture_node = nodes.new(type="ShaderNodeTexImage")
+            if "_back" in map_name:
+                map_name = map_name[:-5] # remove "_back"
+                back[map_name] = texture_node
+            else:
+                front[map_name] = texture_node
+            
             texture_node.image = getCyclesImage(img)
             texture_node.image.colorspace_settings.name = "sRGB" if map_name == "baseColor" else "Non-Color"
-
             if hasattr(texture_node, "color_space"):
                 texture_node.color_space = "COLOR" if map_name == "baseColor" else "NONE"
-            elif map_name == "glossiness":
-                invert_node = nodes.new(type="ShaderNodeInvert")
-                links.new(texture_node.outputs["Color"], invert_node.inputs["Color"])
-                links.new(invert_node.outputs["Color"], current_principled.inputs["Roughness"])
-                current_principled
-            elif map_name == "height":
-                displacement_node = nodes.new(type="ShaderNodeDisplacement")
-                links.new(texture_node.outputs["Color"], displacement_node.inputs["Height"])
-                links.new(displacement_node.outputs["Displacement"], mat_output.inputs[2])
-            elif map_name == "normal":
-                normal_node = nodes.new(type="ShaderNodeNormalMap")
-                links.new(texture_node.outputs["Color"], normal_node.inputs["Color"])
-                links.new(normal_node.outputs["Normal"], current_principled.inputs["Normal"])
-            else:
-                links.new(texture_node.outputs["Color"], current_principled.inputs[__class__.input_tr[map_name]])
-
             if map_name == "opacity":
                 mat.blend_method = 'BLEND'
-            
-            if displacement_node is not None and normal_node is not None:
-                    links.new(normal_node.outputs["Normal"], displacement_node.inputs["Normal"])
 
+        front = back if not front else front # In case just the backside texture was chosen
+
+        def advanced_setup(name, node):
+            if name == "glossiness":
+                invert_node = nodes.new(type="ShaderNodeInvert")
+                links.new(node.outputs["Color"], invert_node.inputs["Color"])
+                links.new(invert_node.outputs["Color"], principled.inputs["Roughness"])
+            elif name == "height":
+                displacement_node = nodes.new(type="ShaderNodeDisplacement")
+                links.new(node.outputs["Color"], displacement_node.inputs["Height"])
+                links.new(displacement_node.outputs["Displacement"], mat_output.inputs[2])
+            elif name == "normal":
+                normal_node = nodes.new(type="ShaderNodeNormalMap")
+                links.new(node.outputs["Color"], normal_node.inputs["Color"])
+                links.new(normal_node.outputs["Normal"], principled.inputs["Normal"])
+
+        if not back: # If there is no item in the back dictionary
+            for name, node in front.items():
+                if __class__.input_tr.get(name):
+                    links.new(node.outputs["Color"], principled.inputs[__class__.input_tr[name]])
+                else:
+                    advanced_setup(name, node)
+        else:
+            geometry_node = nodes.new("ShaderNodeNewGeometry")
+            def setup(name, front, back, mix):
+                links.new(geometry_node.outputs["Backfacing"], mix.inputs[0])
+                links.new(front.outputs["Color"], mix.inputs[1])
+                links.new(back.outputs["Color"], mix.inputs[2])
+                if __class__.input_tr.get(name):
+                    links.new(mix.outputs["Color"], principled.inputs[__class__.input_tr[name]])
+                else:
+                    advanced_setup(name, mix)
+            for name, node in front.items():
+                if back.get(name):
+                    setup(name, node, back[name], nodes.new(type="ShaderNodeMixRGB"))
+        
         autoAlignNodes(mat_output)
 
         return mat

--- a/blender/LilySurfaceScrapper/CyclesMaterialData.py
+++ b/blender/LilySurfaceScrapper/CyclesMaterialData.py
@@ -19,6 +19,10 @@ class CyclesMaterialData(MaterialData):
         'metallic': 'Metallic',
         'specular': 'Specular',
         'opacity': 'Alpha',
+        'emission': 'Emission',
+        'height': '<custom>',
+        'ambientOcclusion': '<custom>', # https://github.com/KhronosGroup/glTF-Blender-IO/issues/123
+        'glossiness': '<custom>',
     }
 
     def loadImages(self):

--- a/blender/LilySurfaceScrapper/CyclesMaterialData.py
+++ b/blender/LilySurfaceScrapper/CyclesMaterialData.py
@@ -80,19 +80,18 @@ class CyclesMaterialData(MaterialData):
                 displacement_node = nodes.new(type="ShaderNodeDisplacement")
                 links.new(texture_node.outputs["Color"], displacement_node.inputs["Height"])
                 links.new(displacement_node.outputs["Displacement"], mat_output.inputs[2])
-                if normal_node is not None:
-                    links.new(normal_node.outputs["Normal"], displacement_node.inputs["Normal"])
             elif map_name == "normal":
                 normal_node = nodes.new(type="ShaderNodeNormalMap")
                 links.new(texture_node.outputs["Color"], normal_node.inputs["Color"])
                 links.new(normal_node.outputs["Normal"], current_principled.inputs["Normal"])
-                if displacement_node is not None:
-                    links.new(normal_node.outputs["Normal"], displacement_node.inputs["Normal"])
             else:
                 links.new(texture_node.outputs["Color"], current_principled.inputs[__class__.input_tr[map_name]])
 
             if map_name == "opacity":
                 mat.blend_method = 'BLEND'
+            
+            if displacement_node is not None and normal_node is not None:
+                    links.new(normal_node.outputs["Normal"], displacement_node.inputs["Normal"])
 
         autoAlignNodes(mat_output)
 

--- a/blender/LilySurfaceScrapper/MaterialData.py
+++ b/blender/LilySurfaceScrapper/MaterialData.py
@@ -37,8 +37,13 @@ class MaterialData(ScrappedData):
             'normal': None,
             'opacity': None,
             'roughness': None,
+            'glossiness': None,
             'metallic': None,
             'specular': None,
+            'height': None,
+            'vectorDisplacement': None,
+            'emission': None,
+            'ambientOcclusion': None,
         }
 
     @classmethod

--- a/blender/LilySurfaceScrapper/Scrappers/CgbookcaseScrapper.py
+++ b/blender/LilySurfaceScrapper/Scrappers/CgbookcaseScrapper.py
@@ -94,6 +94,8 @@ class CgbookcaseScrapper(AbstractScrapper):
             'Opacity': 'opacity',
             'Roughness': 'roughness',
             'Metallic': 'metallic',
+            'Height': 'height',
+            'AO': 'ambientOcclusion',
         }
         for variant_html_data, is_back_side in selected_variants:
             for m in variant_html_data.xpath(".//a"):


### PR DESCRIPTION
This is a patch for #21 , but I also want to handle #20 with just one principled shader (not implemented yet)

Right now I added

- Glossiness
- Height
- Vector Displacement
- Emission
- Ambient Occlusion

to the maps that we internally support. Since Emission is already supported on the Principled BSDF, it's automatically supported in Cycles too.

Additionally I've added support for Height & Glossiness in Cycles and added AO and Height to the CGBookcase scrapper so that these textures are being downloaded too.

What's left to be done:
- ~~Just use one Principled Shader for double sided materials (current implementation prevents the usage of the height node in combination with double sided materials)~~
- ~~Add support for specular textures, so that we support the full specular / glossiness workflow~~
- Come up with a solution for Ambient Occlusion, [possibly mirroring what the devs behind the glTF-Add-on are doing. ](https://github.com/KhronosGroup/glTF-Blender-IO/issues/123)