### PR TITLE
Fix pip installing lxml

### DIFF
--- a/blender/LilySurfaceScrapper/Scrappers/AbstractScrapper.py
+++ b/blender/LilySurfaceScrapper/Scrappers/AbstractScrapper.py
@@ -27,7 +27,7 @@ import string
 import sys
 try:
     from lxml import etree
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     print("No system-wide installation of lxml found. Installing it...")
     import subprocess
     binary_path_python = sys.executable


### PR DESCRIPTION
As expected, there have been some issues. That unfortunately also means that my development environment isn't usable to test for these, as it already worked before the first fix I put here.

Therefore it'll probably take some time until it works for everyone as we'll literally have to work blind.