### PR TITLE
Suggested Fix For lxml Installation

### DIFF
--- a/blender/LilySurfaceScrapper/preferences.py
+++ b/blender/LilySurfaceScrapper/preferences.py
@@ -49,9 +49,9 @@ def modules_path():
     return modulespath
 
 def install_dependencies():
+    # Copied and adapted from https://github.com/jesterKing/import_3dm/blob/9f96e644e40edd571829cbaf777d6bda63dbb5db/import_3dm/read3dm.py
     modulespath = modules_path()
 
-    # Copied and adapted from https://github.com/jesterKing/import_3dm/blob/9f96e644e40edd571829cbaf777d6bda63dbb5db/import_3dm/read3dm.py
     try:
         from subprocess import run as sprun
         try:

--- a/blender/LilySurfaceScrapper/preferences.py
+++ b/blender/LilySurfaceScrapper/preferences.py
@@ -30,9 +30,8 @@ addon_idname = __package__.split(".")[0]
 
 # -----------------------------------------------------------------------------
 
-# --- Block Shamelessly copied from https://github.com/jesterKing/import_3dm/blob/master/import_3dm/read3dm.py
-
 def modules_path():
+    # Copied and adapted from https://github.com/jesterKing/import_3dm/blob/9f96e644e40edd571829cbaf777d6bda63dbb5db/import_3dm/read3dm.py
     # set up addons/modules under the user
     # script path. Here we'll install the
     # dependencies
@@ -55,6 +54,7 @@ def modules_path():
 modules_path()
 
 def install_dependencies():
+    # Copied and adapted from https://github.com/jesterKing/import_3dm/blob/9f96e644e40edd571829cbaf777d6bda63dbb5db/import_3dm/read3dm.py
     modulespath = modules_path()
 
     try:

--- a/blender/LilySurfaceScrapper/preferences.py
+++ b/blender/LilySurfaceScrapper/preferences.py
@@ -42,21 +42,16 @@ def modules_path():
             "modules"
         )
     )
+
     if not os.path.exists(modulespath):
         os.makedirs(modulespath)
 
-    # set user modules path at beginning of paths for earlier hit
-    if sys.path[1] != modulespath:
-        sys.path.insert(1, modulespath)
-
     return modulespath
 
-modules_path()
-
 def install_dependencies():
-    # Copied and adapted from https://github.com/jesterKing/import_3dm/blob/9f96e644e40edd571829cbaf777d6bda63dbb5db/import_3dm/read3dm.py
     modulespath = modules_path()
 
+    # Copied and adapted from https://github.com/jesterKing/import_3dm/blob/9f96e644e40edd571829cbaf777d6bda63dbb5db/import_3dm/read3dm.py
     try:
         from subprocess import run as sprun
         try:

--- a/blender/LilySurfaceScrapper/preferences.py
+++ b/blender/LilySurfaceScrapper/preferences.py
@@ -87,17 +87,6 @@ def install_dependencies():
 
         print("LilySurfaceScrapper: Installing lxml to {}... ".format(modulespath)),
 
-        pip3 = "pip3"
-        if sys.platform=="darwin":
-            pip3 = os.path.normpath(
-                os.path.join(
-                os.path.dirname(bpy.app.binary_path_python),
-                "..",
-                "bin",
-                pip3
-                )
-            )
-
         # call pip in a subprocess so we don't have to mess
         # with internals. Also, this ensures the Python used to
         # install pip is going to be used


### PR DESCRIPTION
Following the bug I described in #86 here is a pull request to hopefully fix the issue.

I tried debugging why lxml could not be imported within the Blender context and found that `sys.path` simply did not include the lxml install location.

I then stumbled upon [this thread](https://devtalk.blender.org/t/can-3rd-party-modules-ex-scipy-be-installed-when-an-add-on-is-installed/9709/6) and followed a link to [this StackExchange answer](https://blender.stackexchange.com/a/153520/90487).

Ultimatey, I copied and adapted [@jesterKing](https://github.com/jesterKing)'s code from the [rhino3dm](https://github.com/jesterKing/import_3dm/blob/master/import_3dm/read3dm.py) addon.

The changes below install the lxml library into the `/addons/modules` path of the Blender installation.

I have tested and verified that it works in Blender 2.90 Alpha on Windows 10 and MacOS 10.14.6.