### PR TITLE
Update CyclesMaterialData.py Blender5.0 error

### DIFF
--- a/blender/LilySurfaceScraper/CyclesMaterialData.py
+++ b/blender/LilySurfaceScraper/CyclesMaterialData.py
@@ -98,7 +98,13 @@ class CyclesMaterialData(MaterialData):
         if map_name == "opacity":
             self.material.blend_method = 'BLEND'
         if map_name == "height":
-            self.material.cycles.displacement_method = 'BOTH'
+            # Blender 4.0+ removed displacement_method from CyclesMaterialSettings
+            # Displacement is now handled purely through shader nodes
+            try:
+                if hasattr(self.material, 'cycles') and hasattr(self.material.cycles, 'displacement_method'):
+                    self.material.cycles.displacement_method = 'BOTH'
+            except (AttributeError, TypeError):
+                pass  # Property doesn't exist in this Blender version
         
         # Save the texture in either the front or back texture dict
         if map_name.endswith("_back"):


### PR DESCRIPTION
Solved blender 5.0 error
Traceback (most recent call last):
  File "C:\Users\user\AppData\Roaming\Blender Foundation\Blender\5.0\scripts\addons\LilySurfaceScraper\frontend.py", line 156, in execute
    data.create_material()
  File "C:\Users\user\AppData\Roaming\Blender Foundation\Blender\5.0\scripts\addons\LilySurfaceScraper\CyclesMaterialData.py", line 101, in create_material
    self.material.cycles.displacement_method = 'BOTH'
AttributeError: 'CyclesMaterialSettings' object has no attribute 'displacement_method'