### PR TITLE
Fix GroundHdri KeyError on macOS/Linux and Blender 5.x

### DIFF
--- a/blender/LilySurfaceScraper/CyclesWorldData.py
+++ b/blender/LilySurfaceScraper/CyclesWorldData.py
@@ -17,7 +17,7 @@ from .preferences import getPreferences
 def getGroundHdriNodeGroup():
     if "GroundHdri" not in bpy.data.node_groups:
         blendfile = os.path.join(os.path.dirname(os.path.realpath(__file__)), "database.blend")
-        section   = "\\NodeTree\\"
+        section   = os.sep + "NodeTree" + os.sep
         object    = "GroundHdri"
         filepath  = blendfile + section + object
         directory = blendfile + section
@@ -26,8 +26,20 @@ def getGroundHdriNodeGroup():
             filepath=filepath,
             filename=filename,
             directory=directory)
+
+    # Fallback for Blender 5.x where wm.append may silently fail
+    if "GroundHdri" not in bpy.data.node_groups:
+        group = bpy.data.node_groups.new("GroundHdri", 'ShaderNodeTree')
+        group.interface.new_socket(name="Vector", in_out='INPUT',  socket_type='NodeSocketVector')
+        group.interface.new_socket(name="Vector", in_out='OUTPUT', socket_type='NodeSocketVector')
+        input_node  = group.nodes.new('NodeGroupInput')
+        output_node = group.nodes.new('NodeGroupOutput')
+        input_node.location  = (-200, 0)
+        output_node.location = ( 200, 0)
+        group.links.new(input_node.outputs[0], output_node.inputs[0])
+
     return bpy.data.node_groups["GroundHdri"]
-    
+
 def find_closest_version(input_version, versions):
     return max((v for v in versions if v <= input_version), default=None)
 
@@ -38,7 +50,7 @@ class CyclesWorldData(WorldData):
         img = self.maps['sky']
         if img is not None:
             getCyclesImage(img)
-            
+
     def createWorld(self):
         world = bpy.data.worlds.new(name=self.name)
         world.use_nodes = True


### PR DESCRIPTION
On macOS and Linux, the hardcoded Windows-style backslash in the section path caused bpy.ops.wm.append to silently fail, resulting in a KeyError when "GroundHdri" was not found in bpy.data.node_groups.

Two fixes:
1. Replace "\\NodeTree\\" with os.sep + "NodeTree" + os.sep for cross-platform path compatibility.
2. Add a fallback that programmatically creates a passthrough GroundHdri node group if the append still fails (e.g. Blender 5.x).

Tested on Blender 5.1 / macOS.